### PR TITLE
make deps is broken (and seemingly unnecessary)

### DIFF
--- a/Docker/systemtest.wrkchain/Dockerfile
+++ b/Docker/systemtest.wrkchain/Dockerfile
@@ -29,7 +29,7 @@ WORKDIR $GOPATH/src/github.com/unification-com
 RUN git clone https://github.com/unification-com/mainchain-cosmos.git --depth 1
 WORKDIR $GOPATH/src/github.com/unification-com/mainchain-cosmos
 
-RUN make deps && make install
+RUN make install
 
 COPY Docker/assets /root/.und_mainchain
 RUN /root/.go/bin/und validate-genesis /root/.und_mainchain/node1/config/genesis.json

--- a/Docker/validator.systemtest/Dockerfile
+++ b/Docker/validator.systemtest/Dockerfile
@@ -29,7 +29,7 @@ WORKDIR $GOPATH/src/github.com/unification-com
 RUN git clone https://github.com/unification-com/mainchain-cosmos.git
 WORKDIR $GOPATH/src/github.com/unification-com/mainchain-cosmos
 
-RUN make deps && make install
+RUN make install
 
 COPY Docker/assets /root/.und_mainchain
 RUN /root/.go/bin/und validate-genesis /root/.und_mainchain/node1/config/genesis.json

--- a/Docker/validator.upstream/Dockerfile
+++ b/Docker/validator.upstream/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR $GOPATH/src/github.com/unification-com
 RUN git clone https://github.com/unification-com/mainchain-cosmos.git
 WORKDIR $GOPATH/src/github.com/unification-com/mainchain-cosmos
 
-RUN make deps && make install
+RUN make install
 
 COPY Docker/assets /root/.und_mainchain
 RUN /root/.go/bin/und validate-genesis /root/.und_mainchain/node1/config/genesis.json


### PR DESCRIPTION
```
/root/.go/pkg/mod/github.com/tendermint/tendermint@v0.32.7/consensus/replay_file.go:278:12: undefined: db.DBBackendType
make: *** [deps] Error 2
Makefile:71: recipe for target 'deps' failed
```
