### PR TITLE
Cacheless REST

### DIFF
--- a/x/beacon/client/rest/query.go
+++ b/x/beacon/client/rest/query.go
@@ -26,6 +26,7 @@ func registerQueryRoutes(cliCtx context.CLIContext, r *mux.Router) {
 
 func beaconParamsHandler(cliCtx context.CLIContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		cliCtx, _ := rest.ParseQueryHeightOrReturnBadRequest(w, cliCtx, r)
 		route := fmt.Sprintf("custom/%s/%s", types.QuerierRoute, keeper.QueryParameters)
 		res, height, err := cliCtx.QueryWithData(route, nil)
 

--- a/x/enterprise/client/rest/query.go
+++ b/x/enterprise/client/rest/query.go
@@ -261,6 +261,7 @@ func EnterpriseAuthAccountOverride(cliCtx context.CLIContext) http.HandlerFunc {
 
 func EnterpriseSupplyTotalOverride(cliCtx context.CLIContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		cliCtx, _ := rest.ParseQueryHeightOrReturnBadRequest(w, cliCtx, r)
 		totalSupplyGetter := keeper.NewTotalSupplyRetriever(cliCtx)
 
 		totalSupply, height, err := totalSupplyGetter.GetTotalSupplyHeight()
@@ -275,7 +276,7 @@ func EnterpriseSupplyTotalOverride(cliCtx context.CLIContext) http.HandlerFunc {
 
 func EnterpriseSupplyByDenomOverride(cliCtx context.CLIContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-
+		cliCtx, _ := rest.ParseQueryHeightOrReturnBadRequest(w, cliCtx, r)
 		denom := mux.Vars(r)["denom"]
 
 		// todo - get from params

--- a/x/enterprise/client/rest/query.go
+++ b/x/enterprise/client/rest/query.go
@@ -41,6 +41,7 @@ func registerEnterpriseSupplyByDenomOverride(cliCtx context.CLIContext, r *mux.R
 
 func enterpriseParamsHandler(cliCtx context.CLIContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		cliCtx, _ := rest.ParseQueryHeightOrReturnBadRequest(w, cliCtx, r)
 		route := fmt.Sprintf("custom/%s/%s", types.QuerierRoute, keeper.QueryParameters)
 		res, height, err := cliCtx.QueryWithData(route, nil)
 
@@ -56,6 +57,7 @@ func enterpriseParamsHandler(cliCtx context.CLIContext) http.HandlerFunc {
 
 func enterpriseTotalLockedHandler(cliCtx context.CLIContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		cliCtx, _ := rest.ParseQueryHeightOrReturnBadRequest(w, cliCtx, r)
 		route := fmt.Sprintf("custom/%s/%s", types.QuerierRoute, keeper.QueryTotalLocked)
 		res, height, err := cliCtx.QueryWithData(route, nil)
 
@@ -71,6 +73,7 @@ func enterpriseTotalLockedHandler(cliCtx context.CLIContext) http.HandlerFunc {
 
 func enterpriseTotalUnLockedHandler(cliCtx context.CLIContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		cliCtx, _ := rest.ParseQueryHeightOrReturnBadRequest(w, cliCtx, r)
 		route := fmt.Sprintf("custom/%s/%s", types.QuerierRoute, keeper.QueryTotalUnlocked)
 		res, height, err := cliCtx.QueryWithData(route, nil)
 

--- a/x/enterprise/internal/keeper/locked_retriever.go
+++ b/x/enterprise/internal/keeper/locked_retriever.go
@@ -88,7 +88,7 @@ func (ar TotalSupplyRetriever) GetTotalSupply() (types.UndSupply, error) {
 	return totalSupply, err
 }
 
-// GetLockedUndHeight queries for locked UND  given an address. Returns the
+// GetLockedUndHeight queries for locked UND given an address. Returns the
 // height of the query with the account. An error is returned if the query
 // or decoding fails.
 func (ar TotalSupplyRetriever) GetTotalSupplyHeight() (types.UndSupply, int64, error) {

--- a/x/wrkchain/client/rest/query.go
+++ b/x/wrkchain/client/rest/query.go
@@ -25,6 +25,7 @@ func registerQueryRoutes(cliCtx context.CLIContext, r *mux.Router) {
 
 func wrkChainParamsHandler(cliCtx context.CLIContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		cliCtx, _ := rest.ParseQueryHeightOrReturnBadRequest(w, cliCtx, r)
 		route := fmt.Sprintf("custom/%s/%s", types.QuerierRoute, keeper.QueryParameters)
 		res, height, err := cliCtx.QueryWithData(route, nil)
 


### PR DESCRIPTION
Simply calling QueryWithData will re-use a REST Client at a particular height