### PR TITLE
Implement Goreleaser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 # Build
 build
 /ev-provision/
+dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,97 @@
+# This is an example goreleaser.yaml file with some sane defaults.
+# Make sure to check the documentation at http://goreleaser.com
+env:
+  - GO111MODULE=on
+
+before:
+  hooks:
+    - go mod verify
+builds:
+  -
+    id: "und"
+    binary: und
+    main: ./cmd/und
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+    ldflags:
+      - -X github.com/cosmos/cosmos-sdk/version.Name=UndMainchain
+      - -X github.com/cosmos/cosmos-sdk/version.ServerName=und
+      - -X github.com/cosmos/cosmos-sdk/version.ClientName=undcli
+      - -X github.com/cosmos/cosmos-sdk/version.Version={{.Version}}
+      - -X github.com/cosmos/cosmos-sdk/version.Commit={{.FullCommit}}
+      - -X "github.com/cosmos/cosmos-sdk/version.BuildTags={{.Env.UND_BUILD_TAGS}}"
+    flags:
+      - -mod=readonly
+      - -tags="{{.Env.UND_BUILD_TAGS}}"
+    hooks:
+      pre: go mod verify
+  -
+    id: "undcli"
+    binary: undcli
+    main: ./cmd/undcli
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - amd64
+    ldflags:
+      - -X github.com/cosmos/cosmos-sdk/version.Name=UndMainchain
+      - -X github.com/cosmos/cosmos-sdk/version.ServerName=und
+      - -X github.com/cosmos/cosmos-sdk/version.ClientName=undcli
+      - -X github.com/cosmos/cosmos-sdk/version.Version={{.Version}}
+      - -X github.com/cosmos/cosmos-sdk/version.Commit={{.FullCommit}}
+      - -X "github.com/cosmos/cosmos-sdk/version.BuildTags={{.Env.UND_BUILD_TAGS}}"
+    flags:
+      - -mod=readonly
+      - -tags="{{.Env.UND_BUILD_TAGS}}"
+    hooks:
+      pre: go mod verify
+
+archives:
+  -
+    id: "und"
+    builds:
+      - und
+    name_template: "{{ .Binary }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format: tar.gz
+    replacements:
+      amd64: x86_64
+    files:
+      - docs/*
+      - LICENSE
+      - README.md
+
+  -
+    id: "undcli"
+    builds:
+      - undcli
+    name_template: "{{ .Binary }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format: tar.gz
+    format_overrides:
+      - goos: windows
+        format: zip
+    replacements:
+      amd64: x86_64
+      darwin: osx
+    files:
+      - docs/*
+      - LICENSE
+      - README.md
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-SNAPSHOT-{{.ShortCommit}}"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^test:'
+      - '^build:'
+      - '^dist:'

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,12 @@ ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=UndMainchain \
 	-X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT) \
 	-X "github.com/cosmos/cosmos-sdk/version.BuildTags=$(build_tags)"
 
+export UND_LDFLAGS = $(ldflags)
+
 include Makefile.devtools
 include Makefile.ledger
 
-BUILD_FLAGS := -tags "$(build_tags)" -ldflags '$(ldflags)'
+BUILD_FLAGS := -tags="$(build_tags)" -ldflags '$(ldflags)'
 
 ifeq ($(WITH_DELVE),yes)
   BUILD_FLAGS += -gcflags 'all=-N -l'
@@ -28,7 +30,7 @@ install: go.sum
 	go install -mod=readonly $(BUILD_FLAGS) ./cmd/und
 	go install -mod=readonly $(BUILD_FLAGS) ./cmd/undcli
 
-build: go.sum
+build: clean go.sum
 	go build -mod=readonly $(BUILD_FLAGS) -o build/und ./cmd/und
 	go build -mod=readonly $(BUILD_FLAGS) -o build/undcli ./cmd/undcli
 
@@ -97,3 +99,9 @@ update-sdk:
 build-update-sdk:
 	go build $(BUILD_FLAGS) -o build/und ./cmd/und
 	go build $(BUILD_FLAGS) -o build/undcli ./cmd/undcli
+
+snapshot: goreleaser
+	UND_BUILD_TAGS="$(build_tags)" goreleaser --snapshot --skip-publish --rm-dist
+
+release: goreleaser
+	UND_BUILD_TAGS="$(build_tags)" goreleaser --rm-dist

--- a/Makefile.devtools
+++ b/Makefile.devtools
@@ -43,11 +43,12 @@ TOOLS_DESTDIR  ?= $(GOPATH)/bin
 
 GOLANGCI_LINT = $(TOOLS_DESTDIR)/golangci-lint
 STATIK        = $(TOOLS_DESTDIR)/statik
-RUNSIM			  = $(TOOLS_DESTDIR)/runsim
+RUNSIM		  = $(TOOLS_DESTDIR)/runsim
+GORELEASER    = $(TOOLS_DESTDIR)/goreleaser
 
 all: tools
 
-tools: statik runsim golangci-lint
+tools: statik runsim golangci-lint goreleaser
 
 golangci-lint: $(GOLANGCI_LINT)
 $(GOLANGCI_LINT): $(mkfile_dir)/install-golangci-lint.sh
@@ -74,8 +75,18 @@ $(RUNSIM):
 	@echo "Installing runsim..."
 	@(cd /tmp && go get github.com/cosmos/tools/cmd/runsim@v1.0.0)
 
+# Install the goreleaser binary with a temporary workaround of entering an outside
+# directory as the "go get" command ignores the -mod option and will polute the
+# go.{mod, sum} files.
+#
+# ref: https://github.com/golang/go/issues/30515
+goreleaser: $(GORELEASER)
+$(GORELEASER):
+	@echo "Installing goreleaser..."
+	@(cd /tmp && go get github.com/goreleaser/goreleaser)
+
 tools-clean:
-	rm -f $(STATIK) $(GOLANGCI_LINT) $(RUNSIM)
+	rm -f $(STATIK) $(GOLANGCI_LINT) $(RUNSIM) $(GORELEASER)
 	rm -f tools-stamp
 
 .PHONY: all tools tools-clean

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ BIP-0044 Path for our HD Wallets is as follows:
 
 SLIP-0044 Coin ID is `5555`
 
+## Pre-compiled binaries
+
+The quickest way to obtain and run the `und` and `undcli` applications is to download
+the pre-compiled binaries from [latest release](https://github.com/unification-com/mainchain/releases)
+
 ## Build
 
 Compile `und` and `undcli` binaries and output to ./build


### PR DESCRIPTION
Implements Goreleaser to allow simpler cross-compiled `und` and `undcli` binaries to be bundled with each release.

The following are compiled:

**`und`**  
Linux x86_64  

**`undcli`**  
Linux x86_64  
OSX x86_64  
Windows x86_64  

**Note:** the `und` server binary is currently only supported on Linux systems. The CLI utility (for sending Txs & queries to the network) is cross-platform.