### PR TITLE
Enterprise whitelist - check on Raise, not Set

### DIFF
--- a/x/enterprise/internal/keeper/purchase.go
+++ b/x/enterprise/internal/keeper/purchase.go
@@ -138,10 +138,6 @@ func (k Keeper) SetPurchaseOrder(ctx sdk.Context, purchaseOrder types.Enterprise
 		return sdkerrors.Wrap(types.ErrMissingData, "unable to set purchase order - purchaser cannot be empty")
 	}
 
-	if !k.AddressIsWhitelisted(ctx, purchaseOrder.Purchaser) {
-		return sdkerrors.Wrap(types.ErrNotAuthorisedToRaisePO, fmt.Sprintf("%s is not whitelisted to raise purchase orders", purchaseOrder.Purchaser))
-	}
-
 	if !purchaseOrder.Amount.IsValid() {
 		return sdkerrors.Wrap(types.ErrInvalidData, "unable to set purchase order - amount not valid")
 	}
@@ -173,6 +169,16 @@ func (k Keeper) RaiseNewPurchaseOrder(ctx sdk.Context, purchaser sdk.AccAddress,
 	purchaseOrderID, err := k.GetHighestPurchaseOrderID(ctx)
 	if err != nil {
 		return 0, err
+	}
+
+	// must have a purchaser
+	if purchaser.Empty() {
+		return 0, sdkerrors.Wrap(types.ErrMissingData, "unable to set purchase order - purchaser cannot be empty")
+	}
+
+	// must be whitelisted
+	if !k.AddressIsWhitelisted(ctx, purchaser) {
+		return 0, sdkerrors.Wrap(types.ErrNotAuthorisedToRaisePO, fmt.Sprintf("%s is not whitelisted to raise purchase orders", purchaser))
 	}
 
 	purchaseOrder := k.GetPurchaseOrder(ctx, purchaseOrderID)

--- a/x/enterprise/internal/keeper/purchase_test.go
+++ b/x/enterprise/internal/keeper/purchase_test.go
@@ -35,7 +35,13 @@ func TestSetGetPurchaseOrder(t *testing.T) {
 		po := types.NewEnterpriseUndPurchaseOrder()
 		po.PurchaseOrderID = i
 		po.Amount = sdk.NewInt64Coin(types.DefaultDenomination, int64(i))
-		po.Purchaser = TestAddrs[1]
+
+		purchaser := TestAddrs[1]
+		// should still be able to SetPurchaseOrder if address is not whitelisted.
+		if i > 500 {
+			purchaser = TestAddrs[2]
+		}
+		po.Purchaser = purchaser
 		po.Status = status
 		po.RaisedTime = ctx.BlockHeader().Time.Unix()
 
@@ -52,7 +58,7 @@ func TestSetGetPurchaseOrder(t *testing.T) {
 		require.True(t, poStatus == status)
 
 		poFrom := keeper.GetPurchaseOrderPurchaser(ctx, i)
-		require.True(t, poFrom.String() == TestAddrs[1].String())
+		require.True(t, poFrom.String() == purchaser.String())
 
 		poAmount := keeper.GetPurchaseOrderAmount(ctx, i)
 		require.True(t, poAmount.Denom == types.DefaultDenomination)
@@ -88,8 +94,6 @@ func TestSetEmptyPurchaseOrderValues(t *testing.T) {
 
 	po7 := po6
 	po7.Status = types.StatusNil
-
-	_ = keeper.AddAddressToWhitelist(ctx, TestAddrs[1])
 
 	testCases := []struct {
 		po          types.EnterpriseUndPurchaseOrder


### PR DESCRIPTION
The Enterprise whitelist can be modified, with addresses added or removed. Purchase Orders from previously whitelisted addresses are retained. During genesis import the keeper's SetPurchaseOrder is called, and therefore any previously valid purchase orders from whitelisted addresses that have subsequently been removed from the whitelist will break the import.

Instead, the whitelist should only be checked with the RaiseNewPurchaseOrder keeper method and not the SetPurchaseOrder method.