### PR TITLE
WRKChain & BEACON Keeper optimisations

### DIFF
--- a/x/beacon/handler.go
+++ b/x/beacon/handler.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/unification-com/mainchain/x/beacon/internal/types"
 	"strconv"
 )
 
@@ -30,6 +31,10 @@ func handleMsgRegisterBeacon(ctx sdk.Context, keeper Keeper, msg MsgRegisterBeac
 
 	if len(msg.Moniker) > 64 {
 		return nil, sdkerrors.Wrap(ErrContentTooLarge, "moniker too big. 64 character limit")
+	}
+
+	if len(msg.Moniker) == 0 {
+		return nil, sdkerrors.Wrap(types.ErrMissingData, "unable to register beacon - must have a moniker")
 	}
 
 	params := NewQueryBeaconParams(1, 1, msg.Moniker, sdk.AccAddress{})

--- a/x/beacon/internal/keeper/record.go
+++ b/x/beacon/internal/keeper/record.go
@@ -20,7 +20,7 @@ func (k Keeper) SetBeaconTimestamp(ctx sdk.Context, beaconTimestamp types.Beacon
 	return nil
 }
 
-// IsBeaconTimestampRecordedByID Check if the BEACON timestamp is present in the store or not, given
+// IsBeaconTimestampRecordedByID Deep Check if the BEACON timestamp is present in the store or not, given
 // the beaconID and timestampID
 func (k Keeper) IsBeaconTimestampRecordedByID(ctx sdk.Context, beaconID uint64, timestampID uint64) bool {
 	store := ctx.KVStore(k.storeKey)
@@ -124,24 +124,13 @@ func (k Keeper) RecordBeaconTimestamp(
 
 	logger := k.Logger(ctx)
 
-	if len(hash) > 66 {
-		return 0, sdkerrors.Wrap(types.ErrContentTooLarge, "hash too big. 66 character limit")
-	}
-
-	if !k.IsBeaconRegistered(ctx, beaconID) {
-		// can't record hashes if BEACON isn't registered
-		return 0, types.ErrBeaconDoesNotExist
-	}
-
 	beacon := k.GetBeacon(ctx, beaconID)
-
-	if !k.IsAuthorisedToRecord(ctx, beacon.BeaconID, owner) {
-		return 0, sdkerrors.Wrapf(types.ErrNotBeaconOwner, "%s not authorised to record hashes for this beacon", owner)
-	}
 
 	timestampID := beacon.LastTimestampID + 1
 
-	beaconTimestamp := k.GetBeaconTimestampByID(ctx, beacon.BeaconID, timestampID)
+	// we're only ever recording new BEACON hashes, never updating existing. Handler has already run
+	// checks for authorisation etc.
+	beaconTimestamp := types.NewBeaconTimestamp()
 
 	beaconTimestamp.BeaconID = beacon.BeaconID
 	beaconTimestamp.TimestampID = timestampID

--- a/x/beacon/internal/keeper/record_test.go
+++ b/x/beacon/internal/keeper/record_test.go
@@ -184,14 +184,9 @@ func TestRecordBeaconTimestampsFail(t *testing.T) {
 		expectedErr error
 		expectedID  uint64
 	}{
-		{0, 0, "", sdk.AccAddress{}, types.ErrBeaconDoesNotExist, 0},
-		{99, 0, "", sdk.AccAddress{}, types.ErrBeaconDoesNotExist, 0},
-		{bID, 1, "hash", TestAddrs[1], sdkerrors.Wrapf(types.ErrNotBeaconOwner, "%s not authorised to record hashes for this beacon", TestAddrs[1]), 0},
-		{bID, 1, "hash", sdk.AccAddress{}, sdkerrors.Wrapf(types.ErrNotBeaconOwner, "%s not authorised to record hashes for this beacon", sdk.AccAddress{}), 0},
 		{bID, 1, "", TestAddrs[0], sdkerrors.Wrap(types.ErrMissingData, "must include owner, id, submit time and hash"), 0},
 		{bID, 0, "timstamphash", TestAddrs[0], sdkerrors.Wrap(types.ErrMissingData, "must include owner, id, submit time and hash"), 0},
 		{bID, 1, "timstamphash", TestAddrs[0], nil, 1},
-		{bID, 2, "0xc14cb7f5c98846be8668e95e99312df0c74391dd328ef07daf66de05920c44a51", TestAddrs[0], sdkerrors.Wrap(types.ErrContentTooLarge, "hash too big. 66 character limit"), 0},
 	}
 
 	for _, tc := range testCases {

--- a/x/beacon/internal/keeper/register.go
+++ b/x/beacon/internal/keeper/register.go
@@ -1,7 +1,6 @@
 package keeper
 
 import (
-	"fmt"
 	"github.com/cosmos/cosmos-sdk/client"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -164,32 +163,12 @@ func (k Keeper) RegisterBeacon(ctx sdk.Context, moniker string, beaconName strin
 
 	logger := k.Logger(ctx)
 
-	//must have a moniker
-	if len(moniker) == 0 {
-		return 0, sdkerrors.Wrap(types.ErrMissingData, "unable to register beacon - must have a moniker")
-	}
-	if len(beaconName) > 128 {
-		return 0, sdkerrors.Wrap(types.ErrContentTooLarge, "name too big. 128 character limit")
-	}
-
-	if len(moniker) > 64 {
-		return 0, sdkerrors.Wrap(types.ErrContentTooLarge, "moniker too big. 64 character limit")
-	}
-
 	beaconID, err := k.GetHighestBeaconID(ctx)
 	if err != nil {
 		return 0, err
 	}
 
-	params := types.NewQueryBeaconParams(1, 1, moniker, sdk.AccAddress{})
-	beacons := k.GetBeaconsFiltered(ctx, params)
-
-	if (len(beacons)) > 0 {
-		errMsg := fmt.Sprintf("beacon already registered with moniker '%s' - id: %d, owner: %s", moniker, beacons[0].BeaconID, beacons[0].Owner)
-		return 0, sdkerrors.Wrap(types.ErrBeaconAlreadyRegistered, errMsg)
-	}
-
-	beacon := k.GetBeacon(ctx, beaconID)
+	beacon := types.NewBeacon()
 
 	beacon.BeaconID = beaconID
 	beacon.Moniker = moniker

--- a/x/beacon/internal/keeper/register_test.go
+++ b/x/beacon/internal/keeper/register_test.go
@@ -1,7 +1,6 @@
 package keeper
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/cosmos/cosmos-sdk/store"
@@ -211,12 +210,9 @@ func TestFailRegisterNewBeacon(t *testing.T) {
 		expectedErr error
 		expectedBID uint64
 	}{
-		{"moniker", "", sdk.AccAddress{}, sdkerrors.Wrap(types.ErrMissingData, "unable to set beacon - must have owner"), 0},
-		{"", "", TestAddrs[0], sdkerrors.Wrap(types.ErrMissingData, "unable to register beacon - must have a moniker"), 0},
 		{"testmoniker", "", TestAddrs[0], nil, 1},
-		{"testmoniker", "", TestAddrs[0], sdkerrors.Wrap(types.ErrBeaconAlreadyRegistered, fmt.Sprintf("beacon already registered with moniker 'testmoniker' - id: 1, owner: %s", TestAddrs[0])), 0},
-		{"c14cb7f5c98846be8668e95e99312df0c74391dd328ef07daf66de05920c44a51", "", TestAddrs[0], sdkerrors.Wrap(types.ErrContentTooLarge, "moniker too big. 64 character limit"), 0},
-		{"c14cb7f5c98846be8668e95e99312df0c74391dd328ef07daf66de05920c44a5", "c14cb7f5c98846be8668e95e99312df0c74391dd328ef07daf66de05920c44a5c14cb7f5c98846be8668e95e99312df0c74391dd328ef07daf66de05920c44a51", TestAddrs[0], sdkerrors.Wrap(types.ErrContentTooLarge, "name too big. 128 character limit"), 0},
+		{"", "", TestAddrs[0], sdkerrors.Wrap(types.ErrMissingData, "unable to set beacon - must have a moniker"), 0},
+		{"", "", sdk.AccAddress{}, sdkerrors.Wrap(types.ErrMissingData, "unable to set beacon - must have owner"), 0},
 	}
 
 	for _, tc := range testCases {

--- a/x/wrkchain/handler.go
+++ b/x/wrkchain/handler.go
@@ -2,6 +2,7 @@ package wrkchain
 
 import (
 	"fmt"
+	"github.com/unification-com/mainchain/x/wrkchain/internal/types"
 	"strconv"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -31,6 +32,10 @@ func handleMsgRegisterWrkChain(ctx sdk.Context, keeper Keeper, msg MsgRegisterWr
 
 	if len(msg.Moniker) > 64 {
 		return nil, sdkerrors.Wrap(ErrContentTooLarge, "moniker too big. 64 character limit")
+	}
+
+	if len(msg.Moniker) == 0 {
+		return nil, sdkerrors.Wrap(types.ErrMissingData, "unable to set WRKChain - must have a moniker")
 	}
 
 	if len(msg.GenesisHash) > 66 {
@@ -101,7 +106,7 @@ func handleMsgRecordWrkChainBlock(ctx sdk.Context, keeper Keeper, msg MsgRecordW
 		return nil, sdkerrors.Wrap(ErrNotWrkChainOwner, "you are not the owner of this WRKChain")
 	}
 
-	if keeper.IsWrkChainBlockRecorded(ctx, msg.WrkChainID, msg.Height) {
+	if keeper.QuickCheckHeightIsRecorded(ctx, msg.WrkChainID, msg.Height) {
 		return nil, sdkerrors.Wrap(ErrWrkChainBlockAlreadyRecorded, "WRKChain block hashes have already been recorded for this height")
 	}
 

--- a/x/wrkchain/internal/keeper/record_test.go
+++ b/x/wrkchain/internal/keeper/record_test.go
@@ -1,7 +1,6 @@
 package keeper
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -186,7 +185,6 @@ func TestRecordWrkchainHashesFail(t *testing.T) {
 	genesisHash := GenerateRandomString(66)
 
 	goodHash := GenerateRandomString(66)
-	tooLongHash := GenerateRandomString(67)
 
 	wcID, err := keeper.RegisterWrkChain(ctx, moniker, name, genesisHash, "geth", TestAddrs[0])
 	require.NoError(t, err)
@@ -202,19 +200,9 @@ func TestRecordWrkchainHashesFail(t *testing.T) {
 		owner       sdk.AccAddress
 		expectedErr error
 	}{
-		{0, 0, "", "", "", "", "", sdk.AccAddress{}, sdkerrors.Wrap(types.ErrWrkChainDoesNotExist, fmt.Sprintf("WRKChain %v does not exist", 0))},
-		{99, 0, "", "", "", "", "", sdk.AccAddress{}, sdkerrors.Wrap(types.ErrWrkChainDoesNotExist, "WRKChain 99 does not exist")},
-		{wcID, 0, "", "", "", "", "", TestAddrs[1], sdkerrors.Wrap(types.ErrNotWrkChainOwner, "not authorised to record hashes for this wrkchain")},
-		{wcID, 0, "", "", "", "", "", sdk.AccAddress{}, sdkerrors.Wrap(types.ErrNotWrkChainOwner, "not authorised to record hashes for this wrkchain")},
 		{wcID, 1, "", "", "", "", "", TestAddrs[0], sdkerrors.Wrap(types.ErrMissingData, "must include owner, id, height and hash")},
 		{wcID, 0, goodHash, "", "", "", "", TestAddrs[0], sdkerrors.Wrap(types.ErrMissingData, "must include owner, id, height and hash")},
 		{wcID, 1, goodHash, "", "", "", "", TestAddrs[0], nil},
-		{wcID, 1, goodHash, "", "", "", "", TestAddrs[0], sdkerrors.Wrap(types.ErrWrkChainBlockAlreadyRecorded, "Block hashes already recorded for this height")},
-		{wcID, 2, tooLongHash, "", "", "", "", TestAddrs[0], sdkerrors.Wrap(types.ErrContentTooLarge, "block hash too big. 66 character limit")},
-		{wcID, 3, goodHash, tooLongHash, "", "", "", TestAddrs[0], sdkerrors.Wrap(types.ErrContentTooLarge, "parent hash too big. 66 character limit")},
-		{wcID, 4, goodHash, goodHash, tooLongHash, "", "", TestAddrs[0], sdkerrors.Wrap(types.ErrContentTooLarge, "hash1 too big. 66 character limit")},
-		{wcID, 5, goodHash, goodHash, goodHash, tooLongHash, "", TestAddrs[0], sdkerrors.Wrap(types.ErrContentTooLarge, "hash2 too big. 66 character limit")},
-		{wcID, 6, goodHash, goodHash, goodHash, goodHash, tooLongHash, TestAddrs[0], sdkerrors.Wrap(types.ErrContentTooLarge, "hash3 too big. 66 character limit")},
 	}
 
 	for _, tc := range testCases {

--- a/x/wrkchain/internal/keeper/register.go
+++ b/x/wrkchain/internal/keeper/register.go
@@ -179,34 +179,12 @@ func (k Keeper) RegisterWrkChain(ctx sdk.Context, moniker string, wrkchainName s
 
 	logger := k.Logger(ctx)
 
-	//must have a moniker
-	if len(moniker) == 0 {
-		return 0, sdkerrors.Wrap(types.ErrMissingData, "unable to set WRKChain - must have a moniker")
-	}
-	if len(moniker) > 64 {
-		return 0, sdkerrors.Wrap(types.ErrContentTooLarge, "moniker too big. 64 character limit")
-	}
-	if len(genesisHash) > 66 {
-		return 0, sdkerrors.Wrap(types.ErrContentTooLarge, "genesis hash too big. 66 character limit")
-	}
-	if len(wrkchainName) > 128 {
-		return 0, sdkerrors.Wrap(types.ErrContentTooLarge, "name too big. 128 character limit")
-	}
-
 	wrkChainId, err := k.GetHighestWrkChainID(ctx)
 	if err != nil {
 		return 0, err
 	}
 
-	params := types.NewQueryWrkChainParams(1, 1, moniker, sdk.AccAddress{})
-	wrkChains := k.GetWrkChainsFiltered(ctx, params)
-
-	if (len(wrkChains)) > 0 {
-		errMsg := fmt.Sprintf("wrkchain already registered with moniker '%s' - id: %d, owner: %s", moniker, wrkChains[0].WrkChainID, wrkChains[0].Owner)
-		return 0, sdkerrors.Wrap(types.ErrWrkChainAlreadyRegistered, errMsg)
-	}
-
-	wrkchain := k.GetWrkChain(ctx, wrkChainId)
+	wrkchain := types.NewWrkChain()
 
 	wrkchain.WrkChainID = wrkChainId
 	wrkchain.Moniker = moniker

--- a/x/wrkchain/internal/keeper/register_test.go
+++ b/x/wrkchain/internal/keeper/register_test.go
@@ -1,7 +1,6 @@
 package keeper
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -214,10 +213,6 @@ func TestRegisterWrkChain(t *testing.T) {
 func TestFailRegisterNewWrkChain(t *testing.T) {
 	ctx, _, keeper := createTestInput(t, false, 100, 0)
 
-	longName := GenerateRandomString(129)
-	longMoniker := GenerateRandomString(65)
-	longGenesisHash := GenerateRandomString(67)
-
 	testCases := []struct {
 		moniker      string
 		name         string
@@ -226,15 +221,9 @@ func TestFailRegisterNewWrkChain(t *testing.T) {
 		expectedErr  error
 		expectedWcID uint64
 	}{
-		{"moniker", "name", "genhash", sdk.AccAddress{}, sdkerrors.Wrap(types.ErrMissingData, "unable to set WRKChain - must have an owner"), 0},
-		{"", "name", "genhash", TestAddrs[0], sdkerrors.Wrap(types.ErrMissingData, "unable to set WRKChain - must have a moniker"), 0},
-		{"", "", "genhash", TestAddrs[0], sdkerrors.Wrap(types.ErrMissingData, "unable to set WRKChain - must have a moniker"), 0},
-		{"", "name", "", TestAddrs[0], sdkerrors.Wrap(types.ErrMissingData, "unable to set WRKChain - must have a moniker"), 0},
 		{"testmoniker", "", "", TestAddrs[0], nil, 1},
-		{"testmoniker", "", "", TestAddrs[0], sdkerrors.Wrap(types.ErrWrkChainAlreadyRegistered, fmt.Sprintf("wrkchain already registered with moniker 'testmoniker' - id: 1, owner: %s", TestAddrs[0])), 0},
-		{longMoniker, "name", "", TestAddrs[0], sdkerrors.Wrap(types.ErrContentTooLarge, "moniker too big. 64 character limit"), 0},
-		{"monikerok", longName, "", TestAddrs[0], sdkerrors.Wrap(types.ErrContentTooLarge, "name too big. 128 character limit"), 0},
-		{"monikerok", "name ok", longGenesisHash, TestAddrs[0], sdkerrors.Wrap(types.ErrContentTooLarge, "genesis hash too big. 66 character limit"), 0},
+		{"", "", "", TestAddrs[0], sdkerrors.Wrap(types.ErrMissingData, "unable to set WRKChain - must have a moniker"), 0},
+		{"", "", "", sdk.AccAddress{}, sdkerrors.Wrap(types.ErrMissingData, "unable to set WRKChain - must have an owner"), 0},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
- remove the repeated checks in keepers, as they are already done in the handler.
- Only check the entire DB for previous WRKChain height submissions if the submitted height <= last height submitted