### PR TITLE
Enable cleveldb support in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ export UND_LDFLAGS = $(ldflags)
 
 include Makefile.devtools
 include Makefile.ledger
+include Makefile.cleveldb
 
 BUILD_FLAGS := -tags="$(build_tags)" -ldflags '$(ldflags)'
 

--- a/Makefile.cleveldb
+++ b/Makefile.cleveldb
@@ -1,0 +1,18 @@
+CLEVELDB_ENABLED ?= false
+
+ifeq ($(CLEVELDB_ENABLED),true)
+  ifeq ($(OS),Windows_NT)
+    GCCEXE = $(shell where gcc.exe 2> NUL)
+    ifeq ($(GCCEXE),)
+      $(error gcc.exe not installed for cleveldb support, please install or set CLEVELDB_ENABLED=false)
+    else
+      build_tags += cleveldb
+      build_tags += gcc
+      ldflags += -X github.com/cosmos/cosmos-sdk/types.DBBackend=cleveldb
+    endif
+  else
+    build_tags += cleveldb
+    build_tags += gcc
+    ldflags += -X github.com/cosmos/cosmos-sdk/types.DBBackend=cleveldb
+  endif
+endif

--- a/README.md
+++ b/README.md
@@ -51,6 +51,21 @@ $ cd mainchain
 $ make install
 ```
 
+#### cleveldb support
+
+To build with cleveldb as the database backend, run:
+
+```bash 
+CLEVELDB_ENABLED=true make install
+```
+
+Once the node has been initialised, the DB backend can be set in
+`$HOME/.und_mainchain/confog/config.toml`:
+
+```toml 
+db_backend = "cleveldb"
+```
+
 ### Build from source
 
 Clone latest release for running on MainNet
@@ -73,6 +88,21 @@ $ make build
 ```
 
 `und` and `undcli` binaries and output to `./build`. This is useful for development and testing.
+
+#### cleveldb support
+
+To build with cleveldb as the database backend, run:
+
+```bash 
+CLEVELDB_ENABLED=true make build
+```
+
+Once the node is initialised, the DB backend can be set in
+`$HOME/.und_mainchain/confog/config.toml`:
+
+```toml 
+db_backend = "cleveldb"
+```
 
 ### Dockerised `und` and `undcli`
 


### PR DESCRIPTION
Allow cleveldb as an option for the database backend in addition to the default goleveldb. Can be enabled during compilation.