### PR TITLE
Scanlan tx cmd fixes

### DIFF
--- a/x/beacon/client/cli/tx.go
+++ b/x/beacon/client/cli/tx.go
@@ -101,7 +101,7 @@ $ %s tx %s register --moniker=MyBeacon --name="My WRKChain" --from mykey
 
 		},
 	}
-	//flags.AddTxFlagsToCmd(cmd)
+	flags.AddTxFlagsToCmd(cmd)
 	cmd.Flags().String(FlagMoniker, "", "BEACON's moniker")
 	cmd.Flags().String(FlagName, "", "(optional) BEACON's name")
 	return cmd
@@ -174,7 +174,7 @@ $ %s tx %s record 1 --hash=d04b98f48e8 --subtime=1234356 --from mykey
 
 		},
 	}
-	//flags.AddTxFlagsToCmd(cmd)
+	flags.AddTxFlagsToCmd(cmd)
 	cmd.Flags().String(FlagTimestampHash, "", "BEACON's timestamp hash")
 	cmd.Flags().Uint64(FlagSubmitTime, 0, "BEACON's timestamp submission time")
 	return cmd
@@ -249,6 +249,6 @@ $ %s tx %s purchase_storage 1 100
 
 		},
 	}
-	//flags.AddTxFlagsToCmd(cmd)
+	flags.AddTxFlagsToCmd(cmd)
 	return cmd
 }

--- a/x/enterprise/client/cli/tx.go
+++ b/x/enterprise/client/cli/tx.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"github.com/cosmos/cosmos-sdk/client/flags"
 	"strconv"
 	"strings"
 
@@ -78,7 +79,7 @@ $ %s tx %s purchase 1000000000000%s --from wrktest
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}
-	//flags.AddTxFlagsToCmd(cmd)
+	flags.AddTxFlagsToCmd(cmd)
 	return cmd
 }
 
@@ -127,7 +128,7 @@ $ %s tx %s process 24 reject --from ent
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}
-	//flags.AddTxFlagsToCmd(cmd)
+	flags.AddTxFlagsToCmd(cmd)
 	return cmd
 }
 
@@ -176,6 +177,6 @@ $ %s tx %s whitelist remove und1x8pl6wzqf9atkm77ymc5vn5dnpl5xytmn200xy --from en
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}
-	//flags.AddTxFlagsToCmd(cmd)
+	flags.AddTxFlagsToCmd(cmd)
 	return cmd
 }

--- a/x/stream/client/cli/tx.go
+++ b/x/stream/client/cli/tx.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"github.com/cosmos/cosmos-sdk/client/flags"
 	"strconv"
 	"strings"
 
@@ -81,7 +82,7 @@ $ %s tx %s create und173qnkw458p646fahmd53xa45vqqvga7kyu6ryy 777000000000nund 29
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}
-	//flags.AddTxFlagsToCmd(cmd)
+	flags.AddTxFlagsToCmd(cmd)
 	return cmd
 }
 
@@ -120,7 +121,7 @@ $ %s tx %s claim und173qnkw458p646fahmd53xa45vqqvga7kyu6ryy --from t1
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}
-	//flags.AddTxFlagsToCmd(cmd)
+	flags.AddTxFlagsToCmd(cmd)
 	return cmd
 }
 
@@ -164,7 +165,7 @@ $ %s tx %s topup und173qnkw458p646fahmd53xa45vqqvga7kyu6ryy 100000000000nund --f
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}
-	//flags.AddTxFlagsToCmd(cmd)
+	flags.AddTxFlagsToCmd(cmd)
 	return cmd
 }
 
@@ -208,7 +209,7 @@ $ %s tx %s update-flow und173qnkw458p646fahmd53xa45vqqvga7kyu6ryy 246973 --from 
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}
-	//flags.AddTxFlagsToCmd(cmd)
+	flags.AddTxFlagsToCmd(cmd)
 	return cmd
 }
 
@@ -247,6 +248,6 @@ $ %s tx %s cancel und173qnkw458p646fahmd53xa45vqqvga7kyu6ryy --from t1
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}
-	//flags.AddTxFlagsToCmd(cmd)
+	flags.AddTxFlagsToCmd(cmd)
 	return cmd
 }

--- a/x/wrkchain/client/cli/tx.go
+++ b/x/wrkchain/client/cli/tx.go
@@ -111,7 +111,7 @@ $ %s tx %s register --moniker="MyWrkChain" --genesis="d04b98f48e8f8bcc15c6ae5ac0
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}
-	//flags.AddTxFlagsToCmd(cmd)
+	flags.AddTxFlagsToCmd(cmd)
 	cmd.Flags().String(FlagMoniker, "", "WRKChain's moniker")
 	cmd.Flags().String(FlagName, "", "(optional) WRKChain's name")
 	cmd.Flags().String(FlagGenesisHash, "", "(optional) WRKChain's Genesis hash")
@@ -194,7 +194,7 @@ $ %s tx %s record 1 --wc_height=26 --block_hash="d04b98f48e8" --parent_hash="f8b
 		},
 	}
 
-	//flags.AddTxFlagsToCmd(cmd)
+	flags.AddTxFlagsToCmd(cmd)
 	cmd.Flags().Uint64(FlagWcHeight, 0, "WRKChain block's height/block number")
 	cmd.Flags().String(FlagBlockHash, "", "WRKChain block's header (main) hash")
 	cmd.Flags().String(FlagParentHash, "", "(optional) WRKChain block's parent hash")
@@ -273,6 +273,6 @@ $ %s tx %s purchase_storage 1 100
 
 		},
 	}
-	//flags.AddTxFlagsToCmd(cmd)
+	flags.AddTxFlagsToCmd(cmd)
 	return cmd
 }


### PR DESCRIPTION
Since `autocli` is not being used for the Tx commands, need to add `flags.AddTxFlagsToCmd(cmd)` to each Tx cmd.